### PR TITLE
Fix WWCode header logo circle

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -37,9 +37,7 @@ class Header extends React.Component {
       <React.Fragment>
         <header className={`header ${this.getHeaderSize()}`}>
           <Link to="/" className="logoType">
-            <div className="logo">
-              <img src={config.gravatarImgMd5=="" ? avatar : config.gravatarImgMd5 } alt={config.siteTitle} />
-            </div>
+            <div className="logo" />
             <div className="type">
               <h1>{config.headerTitle}</h1>
               <h2>{config.headerSubTitle}</h2>
@@ -111,7 +109,12 @@ class Header extends React.Component {
           }
 
           .logo {
-            border-radius: 65% 75%;
+            border-radius: 50%;
+            background-image: url(${config.gravatarImgMd5 === "" ? avatar : config.gravatarImgMd5});
+            background-size: contain;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-color: #fff;
             border: 1px solid #eee;
             display: inline-block;
             height: 44px;


### PR DESCRIPTION
Fix header logo circle by using a background image in the logo `div`, instead of using a `img` tag

# Demo

* Before:
![image](https://user-images.githubusercontent.com/14980353/47191833-656d7b00-d2fe-11e8-8868-662d7a8313a1.png)

* After:
![image](https://user-images.githubusercontent.com/14980353/47191826-571f5f00-d2fe-11e8-8240-685cf9c878a9.png)

