### PR TITLE
fix typos on "Welcom to Hackotobuurfest 2018!" title

### DIFF
--- a/src/components/Hero/Hero.js
+++ b/src/components/Hero/Hero.js
@@ -10,7 +10,8 @@ const Hero = props => {
     <React.Fragment>
       <section className="hero">
         <h1>
-          Welcom to Hackotobuurfest 2018!
+          Welcome to
+          <span>Hacktoberfest 2018!</span>
         </h1>
         <button onClick={scrollToContent} aria-label="scroll">
           <FaArrowDown />
@@ -41,6 +42,10 @@ const Hero = props => {
           color: ${theme.hero.h1.color};
           line-height: ${theme.hero.h1.lineHeight};
           text-remove-gap: both 0 "Open Sans";
+
+          span {
+            display: block;
+          }
 
           :global(strong) {
             position: relative;


### PR DESCRIPTION
# Implements
**It closes** #2   

# Description
Our front-end dev wrote this home page on too little sleep, and there are several typos on the main page. Find them and fix them, please.

When submitting your PR, please explain the typos you fixed.

# Before
**Was fixed:** "Welcom to Hackotobuurfest 2018" title
![image](https://user-images.githubusercontent.com/9702671/47200466-e5fe9c80-d33b-11e8-9689-633d77dba811.png)

# After
**The title now is:** "Welcome to Hacktoberfest 2018!"
![image](https://user-images.githubusercontent.com/9702671/47200433-c7000a80-d33b-11e8-8f5e-846064ef1781.png)
